### PR TITLE
refactor: removendo o atributo altura da classe de triangulo isoscele…

### DIFF
--- a/src/models/TrianguloIsosceles.ts
+++ b/src/models/TrianguloIsosceles.ts
@@ -1,20 +1,13 @@
 import Triangulo from "./Triangulo.js";
 
 class TrianguloIsosceles extends Triangulo{
-    private altura : number;
-
-    constructor(base : number, lado : number, altura : number = null){
+    constructor(base : number, lado : number){
         super(base, lado, lado);
-        this.altura = altura;
-    }
-
-    public getAltura() : number {
-        return this.altura;
     }
 
     public calcularAltura(): number {
-        this.altura = Math.sqrt((this.ladoB**2) - ((this.ladoA / 2)**2))
-        return this.altura;
+        let altura : number = Math.sqrt((this.ladoB**2) - ((this.ladoA / 2)**2))
+        return altura;
     }
 
     public calcularArea() : number {

--- a/src/services/TrianguloIsoscelesService.ts
+++ b/src/services/TrianguloIsoscelesService.ts
@@ -1,7 +1,7 @@
 import TrianguloIsosceles from "../models/TrianguloIsosceles.js";
 
 class TrianguloIsoscelesService{
-    public verificarDadosTrianguloIsosceles(base : number = null, lado : number = null, altura: number = null) : TrianguloIsosceles{
+    public verificarDadosTrianguloIsosceles(base : number = null, lado : number = null) : TrianguloIsosceles{
         if(lado <= 0 || base <= 0){
             throw new Error("Lado deve ser maior que zero.");
         }
@@ -10,7 +10,7 @@ class TrianguloIsoscelesService{
             throw new Error("O lado de um triângulo isósceles deve ser maior do que a metade de sua base.");
         } 
 
-        let isosceles : TrianguloIsosceles = new TrianguloIsosceles(base, lado, altura);
+        let isosceles : TrianguloIsosceles = new TrianguloIsosceles(base, lado);
         return isosceles;
     }
 }


### PR DESCRIPTION
Removendo o atributo altura da classe de triangulo isosceles e qualquer local que ele seja mencionado.

Motivo: Atributo altura estava sendo inutil no codigo, nao sendo chamado nem definido em nenhum momento.